### PR TITLE
File.exists? is deprecated and removed in Ruby 3.2

### DIFF
--- a/rswag-ui/lib/open_api/rswag/ui/middleware.rb
+++ b/rswag-ui/lib/open_api/rswag/ui/middleware.rb
@@ -38,7 +38,7 @@ module OpenApi
         end
 
         def template_filename
-          @config.template_locations.find { |filename| File.exists?(filename) }
+          @config.template_locations.find { |filename| File.exist?(filename) }
         end
       end
     end


### PR DESCRIPTION
`File.exists?` is deprecated and removed in Ruby 3.2

 https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/